### PR TITLE
Populate open item name on load

### DIFF
--- a/px-context-browser.html
+++ b/px-context-browser.html
@@ -489,6 +489,11 @@ Define how your data will come in using these methods:
           }
         }
         recursiveAddChildren(root.children);
+        // Repopulate the openedItemName and Breadcrumbs if we have a directContext
+        if (this.selectedItem && this.selectedItem.name) {
+          this.configureBreadcrumbs();
+          this.openedItemName = this.selectedItem.name;
+        }
       },
       /**
        * Appends children to those already at a level.


### PR DESCRIPTION
When passing a direct context object, the opened item name and
breadcrumbs were not populating on load.
